### PR TITLE
daemon.c: Fix variable overflow.

### DIFF
--- a/go/testimonyd/daemon.c
+++ b/go/testimonyd/daemon.c
@@ -95,8 +95,9 @@ int AFPacket(const char* iface, int block_size, int block_nr, int block_ms,
 
   // MMap the RX_RING to create a packet memory region.
   *ring =
-      mmap(NULL, tp3.tp_block_size * tp3.tp_block_nr, PROT_READ | PROT_WRITE,
-           MAP_SHARED | MAP_LOCKED | MAP_NORESERVE, *fd, 0);
+      mmap(NULL, (size_t) tp3.tp_block_size * tp3.tp_block_nr,
+           PROT_READ | PROT_WRITE, MAP_SHARED | MAP_LOCKED | MAP_NORESERVE,
+           *fd, 0);
   if (*ring == MAP_FAILED) {
     *err = "ring mmap failed";
     errno = EINVAL;


### PR DESCRIPTION
The mmap's length argument should be of type "size_t".
Before this fix, the implementation has the risk of
overflow since the length is calculated by the
multiply of two "unsigned int".

Signed-off-by: Alex Wang alex@awakenetworks.com
