### PR TITLE
FanoutID config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ these configuration options:
      `MemoryRegionSize` is `BlockSize * NumBlocks`.  FanoutSize can be
      considered the number of parallel processes that want to access packet
      data.
+*   **FanoutID:**  Integer fanout ID to use when setting socket options. These
+     are globally unique so it can be tuned to avoid conflicts with other
+     processes that use AF_PACKET. If unspecified or 0 an ID will be auto
+     assigned starting with 1.
 *   **User:** This socket will be owned by the given user, mode `0600`.  This
      allows root to provide different sockets with different capabilities to
      specific users.

--- a/go/testimonyd/internal/socket/daemon.go
+++ b/go/testimonyd/internal/socket/daemon.go
@@ -88,6 +88,7 @@ func (s SocketConfig) gid() (int, error) {
 
 // RunTestimony runs the testimonyd server given the passed in configuration.
 func RunTestimony(t Testimony) {
+	fanoutID := 0
 	autoID := 1
 	names := map[string]bool{}
 	// Populate a map of manually defined IDs to avoid auto assignment conflicts.
@@ -113,12 +114,12 @@ func RunTestimony(t Testimony) {
 
 		// Set fanoutID from config or find next available id.
 		if sc.FanoutID > 0 {
-			fanoutID := sc.FanoutID
+			fanoutID = sc.FanoutID
 		} else {
 			for ids[autoID] {
 				autoID++
 			}
-			fanoutID := autoID
+			fanoutID = autoID
 			autoID++
 		}
 		// Set up FanoutSize sockets and start goroutines to manage each.


### PR DESCRIPTION
This adds FanoutID as an option to the config file.  This is useful to avoid conflicts with other applications that might try to use ID 1.  For example Suricata start-up fanout support tests:

https://github.com/OISF/suricata/blob/7da805ffd9a9202c67d53ef6a06c3215436495e9/src/source-af-packet.c#L1971
