### PR TITLE
Fix crash on first connection when FanoutSize is zero or unspecified

### DIFF
--- a/go/testimonyd/daemon.go
+++ b/go/testimonyd/daemon.go
@@ -51,5 +51,10 @@ func main() {
 	if err := json.NewDecoder(bytes.NewBuffer(confdata)).Decode(&t); err != nil {
 		log.Fatalf("could not parse configuration %q: %v", *confFilename, err)
 	}
+	for i, _ := range t {
+		if t[i].FanoutSize == 0 {
+			t[i].FanoutSize = 1
+		}
+	}
 	socket.RunTestimony(t)
 }


### PR DESCRIPTION
FanoutSize is now assumed to be 1 (no fanout) instead of 0 if not specified in config. 0 FanoutSize previously led to out-of-bounds error on first client connection